### PR TITLE
Some minor fixes to boilerplate, and comments

### DIFF
--- a/Source/Client/ClientPatch.csproj
+++ b/Source/Client/ClientPatch.csproj
@@ -24,7 +24,7 @@
 
   <ItemGroup>
     <Reference Include="GameClient">
-      <HintPath>..\..\..\Rimworld-Together\Source\Client\bin\Debug\net472\GameClient.dll</HintPath>
+      <HintPath>..\..\..\Rimworld-Together\Source\Client\bin\Release\net472\GameClient.dll</HintPath>
       <Private>False</Private>
     </Reference>
   </ItemGroup>

--- a/Source/Client/Main.cs
+++ b/Source/Client/Main.cs
@@ -2,6 +2,8 @@
 using GameClient;
 using Shared;
 
+// You need to clone Rimworld-Together, and put Boilerplate in the same folder, as Rimworld-Together
+
 namespace RTPatch
 {
     // This class is the entry point for your CLIENT patch.

--- a/Source/Server/Main.cs
+++ b/Source/Server/Main.cs
@@ -2,6 +2,8 @@
 using GameServer;
 using Shared;
 
+// You need to clone Rimworld-Together, and put Boilerplate in the same folder, as Rimworld-Together
+
 namespace RTPatch
 {
     // This class is the entry point for your SERVER patch.


### PR DESCRIPTION
If you used builder, GameClient will be generated at Release folder, no matter what you do, but this project tried to reference it in Debug folder.

And comments, about adding having Rimworld-Together and RTPatches repositories in the same folder